### PR TITLE
Remove Django 1.8 dependency in initial migration

### DIFF
--- a/generic_links/migrations/0001_initial.py
+++ b/generic_links/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
+        ('contenttypes', '__first__'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
The `('contenttypes', '0002_remove_content_type_name')` migration was part of Django 1.8, replacing it with `'__first__'` allows the use of Django 1.7