### PR TITLE
Fix for Django 1.9

### DIFF
--- a/generic_links/admin.py
+++ b/generic_links/admin.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 from django.contrib import admin
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes import admin as ct_admin
 
 from generic_links.models import GenericLink
 
 
-class GenericLinkStackedInline(generic.GenericStackedInline):
+class GenericLinkStackedInline(ct_admin.GenericStackedInline):
     model = GenericLink
     extra = 1
 
 
-class GenericLinkTabularInline(generic.GenericTabularInline):
+class GenericLinkTabularInline(ct_admin.GenericTabularInline):
     model = GenericLink
     extra = 1
 

--- a/generic_links/models.py
+++ b/generic_links/models.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 from django import VERSION
 from django.conf import settings
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -24,7 +24,7 @@ class GenericLink(models.Model):
 
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField(db_index=True)
-    content_object = generic.GenericForeignKey()
+    content_object = GenericForeignKey()
 
     url = models.URLField()
     title = models.CharField(max_length=200)


### PR DESCRIPTION
The contenttypes generic module has been refactored in Django 1.9. Only Django 1.8 and Django 1.9 are currently supported so didn’t make it backwards compatible with <Django 1.8